### PR TITLE
Fix a bug that prevents being able to read blueprints

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Unit.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Unit.cs
@@ -214,7 +214,7 @@ public partial struct GetGamedataFile
 			return CreateEmptyUnit(LocalPath);
 		}
 
-		BluePrintString = BluePrintString.Replace("UnitBlueprint {", "UnitBlueprint = {");
+		BluePrintString = BluePrintString.Replace("UnitBlueprint", "UnitBlueprint =");
 
 		string[] PathSplit = LocalPath.Split('/');
 		GameObject NewUnit = new GameObject(PathSplit[PathSplit.Length - 1].Replace(".bp", ""));


### PR DESCRIPTION
```
[string "chunk"]:35: attempt to call global 'UnitBlueprint' (a nil value)
Lua (at <no source>)
units/ues0304/ues0304_unit.bp 
(Filename: C:\buildslave\unity\build\Runtime/Export/Debug/Debug.bindings.h Line: 35)
```

![image](https://github.com/Garanas/FAForeverMapEditor/assets/15778155/031948a0-cbcc-4cbe-82e0-64a0a9440461)
